### PR TITLE
'target' in transition may be callable

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -371,11 +371,16 @@ class FSMKeyField(FSMFieldMixin, models.ForeignKey):
     """
     State Machine support for Django model
     """
-    def get_state(self, instance):
-        return instance.__dict__[self.attname]
-
     def set_state(self, instance, state):
-        instance.__dict__[self.attname] = self.to_python(state)
+        if callable(state):
+            state = state()
+        instance.__setattr__(self.attname, self.to_python(state))
+
+    def get_state(self, instance):
+        if callable(instance.__dict__[self.attname]):
+            return instance.__dict__[self.attname]()
+        else:
+            return instance.__dict__[self.attname]
 
 
 class ConcurrentTransitionMixin(object):

--- a/django_fsm/tests/test_key_field.py
+++ b/django_fsm/tests/test_key_field.py
@@ -23,6 +23,9 @@ class DBState(models.Model):
     class Meta:
         app_label = 'django_fsm'
 
+def hidden():
+    if django_apps.models_ready:
+        return django_apps.get_model('testapp', 'DbState').objects.get(id = 'hidden')
 
 class FKBlogPost(models.Model):
     state = FSMKeyField(DBState, default='new', protected=True)
@@ -35,7 +38,7 @@ class FKBlogPost(models.Model):
     def notify_all(self):
         pass
 
-    @transition(field=state, source='published', target='hidden')
+    @transition(field=state, source='published', target=hidden())
     def hide(self):
         pass
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,6 +1,10 @@
+from django.apps.registry import apps as django_apps
 from django.db import models
 from django_fsm import FSMField, FSMKeyField, transition
 
+def dept():
+    if django_apps.models_ready:
+        return django_apps.get_model('testapp', 'DbState').objects.get(id = 'dept')
 
 class Application(models.Model):
     """
@@ -61,7 +65,7 @@ class FKApplication(models.Model):
     def dean_approved(self):
         pass
 
-    @transition(field=state, source='dean', target='dept')
+    @transition(field=state, source='dean', target=dept())
     def dean_rejected(self):
         pass
 


### PR DESCRIPTION
it is useful when FSMKeyField is in use
also, using instance.__setattr__ instead of instace.__dict__ in FSMKeyField().set_state()
