### PR TITLE
issue: #63 first take at object level permissions

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -73,10 +73,12 @@ class Transition(object):
     def name(self):
         return self.method.__name__
 
-    def has_perm(self, user):
+    def has_perm(self, user, obj):
         if not self.permission:
             return True
         elif callable(self.permission) and self.permission(user):
+            return True
+        elif not callable(self.permission) and user.has_perm(self.permission, obj):
             return True
         elif user.has_perm(self.permission):
             return True
@@ -115,7 +117,7 @@ def get_available_user_FIELD_transitions(instance, user, field):
     with all conditions met and user have rights on it
     """
     for transition in get_available_FIELD_transitions(instance, field):
-        if transition.has_perm(user):
+        if transition.has_perm(user, instance):
             yield transition
 
 
@@ -171,7 +173,7 @@ class FSMMeta(object):
         if not transition:
             return False
         else:
-            return transition.has_perm(user)
+            return transition.has_perm(user, instance)
 
     def next_state(self, current_state):
         transition = self.get_transition(current_state)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,5 @@
 PROJECT_APPS = ('django_fsm', 'testapp',)
-INSTALLED_APPS = ('django.contrib.contenttypes', 'django.contrib.auth', 'django_jenkins',) + PROJECT_APPS
+INSTALLED_APPS = ('django.contrib.contenttypes', 'guardian', 'django.contrib.auth', 'django_jenkins',) + PROJECT_APPS
 DATABASE_ENGINE = 'sqlite3'
 SECRET_KEY = 'nokey'
 MIDDLEWARE_CLASSES = ()
@@ -13,3 +13,7 @@ JENKINS_TASKS = (
     'django_jenkins.tasks.run_pep8',
     'django_jenkins.tasks.run_pyflakes'
 )
+
+ANONYMOUS_USER_ID = 0
+AUTHENTICATION_BACKENDS = ('django.contrib.auth.backends.ModelBackend',)
+GUARDIAN_SETTING = AUTHENTICATION_BACKENDS + ('guardian.backends.ObjectPermissionBackend',)

--- a/tests/testapp/tests/test_object_permissions.py
+++ b/tests/testapp/tests/test_object_permissions.py
@@ -1,0 +1,24 @@
+from django.contrib.auth.models import User, Permission
+from django.test.utils import override_settings
+from django.conf import settings
+
+from guardian.shortcuts import assign_perm, remove_perm
+
+from django_fsm import has_transition_perm
+from testapp.models import BlogPost
+from .test_permissions import PermissionFSMFieldTest
+
+
+@override_settings(AUTHENTICATION_BACKENDS=settings.GUARDIAN_SETTING)
+class ObjectPermissionFSMFieldTest(PermissionFSMFieldTest):
+    def setUp(self):
+        super(ObjectPermissionFSMFieldTest, self).setUp()
+        self.obj_model = BlogPost.objects.create()
+        self.object_only_privileged = User.objects.create(username='object_only_privileged')
+        assign_perm('can_publish_post', self.object_only_privileged, self.obj_model)
+
+    def test_object_only_access_success(self):
+        self.assertTrue(has_transition_perm(self.obj_model.publish, self.object_only_privileged))
+
+    def test_object_only_other_access_prohibited(self):
+        self.assertFalse(has_transition_perm(self.model.publish, self.object_only_privileged))

--- a/tests/testapp/tests/test_permissions.py
+++ b/tests/testapp/tests/test_permissions.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User, Permission
 from django.test import TestCase
 
+
 from django_fsm import has_transition_perm
 from testapp.models import BlogPost
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands = python tests/manage.py {posargs:jenkins --pep8-max-line-length=150 --
 deps = -r{toxinidir}/requirements.txt
        graphviz>=0.4
        django-jenkins
+       django-guardian
        coverage
        pep8
        pyflakes
@@ -18,6 +19,7 @@ deps = django==1.6.5
        ipython==2.1.0
        graphviz>=0.4
        django-jenkins
+       django-guardian
        coverage
        pep8
        pyflakes
@@ -28,6 +30,7 @@ basepython = python3.3
 deps = git+https://github.com/django/django.git
        graphviz>=0.4
        django-jenkins
+       django-guardian
        coverage
        pep8
        pyflakes


### PR DESCRIPTION
All tests pass, not really sure if you want me to subclass other tests to see if it all works when guardian is there. The current implementation does not distinguish between backends, that means it will test for a global permission and for an object permission. That might not be the desired effect, so it should be stated in the documentation.

An alternative approach would be to be able to define the Transition object as a setting, and be able to include different mixins or has_perm can be completely configurable for the most wacky settings without django-fsm having any external dependencies. Just let me know what you think. I want to have this in staging in a month :)

And furthermore, for now callables don't work with object level permission checking. 