### PR TITLE
Support for boolean FSM field

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -373,6 +373,13 @@ class FSMIntegerField(FSMFieldMixin, models.IntegerField):
     pass
 
 
+class FSMBooleanField(FSMFieldMixin, models.BooleanField):
+    """
+    Same as FSMField, but stores the state value in a BooleanField.
+    """
+    pass
+
+
 class FSMKeyField(FSMFieldMixin, models.ForeignKey):
     """
     State Machine support for Django model


### PR DESCRIPTION
I needed support for a very simple boolean state machine, so here it is.

Not much to it: I originally thought I needed another change for transitioning to False, but apparently this is already covered in the recent fix for empty strings (d5d0df9f1522e6f38400ab9161834a2a0af03cc0)