### PR TITLE
In order to allow having a StateMachine abstract Model we need to allow

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -202,7 +202,8 @@ class FSMFieldDescriptor(object):
 
     def __get__(self, instance, type=None):
         if instance is None:
-            raise AttributeError('Can only be accessed via an instance.')
+            # If class access return a reference to the field to allow inheritance
+            return self.field
         return self.field.get_state(instance)
 
     def __set__(self, instance, value):


### PR DESCRIPTION
subclasses to reference the state field in the extended transitions such as
AbstractStateMachineModel.state_field.