### PR TITLE
Document and test the field parameter when accepting a string.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,8 @@ Use the ``transition`` decorator to annotate model methods
 
 ``source`` parameter accepts a list of states, or an individual state.
 You can use ``*`` for source, to allow switching to ``target`` from any
-state.
+state. The ``field`` paramter accepts both a string attribute name or an
+actual field instance.
 
 If calling publish() succeeds without raising an exception, the state
 field will be changed, but not written to the database.

--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -264,7 +264,10 @@ class FSMFieldMixin(object):
         return name, path, args, kwargs
 
     def get_state(self, instance):
-        return instance.__dict__[self.name]
+        if self.name in instance.__dict__:
+            return instance.__dict__[self.name]
+
+        return getattr(instance, self.name)
 
     def set_state(self, instance, state):
         instance.__dict__[self.name] = state

--- a/tests/testapp/tests/test_string_field_parameter.py
+++ b/tests/testapp/tests/test_string_field_parameter.py
@@ -1,0 +1,32 @@
+from django.db import models
+from django.test import TestCase
+from django_fsm import FSMField, transition
+
+
+class BlogPostWithStringField(models.Model):
+    state = FSMField(default='new')
+
+    @transition(field='state', source='new', target='published', conditions=[])
+    def publish(self):
+        pass
+
+    @transition(field='state', source='published', target='destroyed')
+    def destroy(self):
+        pass
+
+    @transition(field='state', source='published', target='review')
+    def review(self):
+        pass
+
+    class Meta:
+        app_label = 'testapp'
+
+
+class StringFieldTestCase(TestCase):
+    def setUp(self):
+        self.model = BlogPostWithStringField()
+
+    def test_initial_state(self):
+        self.assertEqual(self.model.state, 'new')
+        self.model.publish()
+        self.assertEqual(self.model.state, 'published')


### PR DESCRIPTION
So I'm sorry #109 got off to a bad start. This MR adds a line to the readme saying that the `field` parameter accepts a string as well as a field instance and also adds a test to ensure that it works.

I also made a change to the `get_state` function, it's possible that the field doesn't exist in the instances `__dict__` attribute and in that case the function falls back to `getattr`.