### PR TITLE
WIP: Use setattr as a fallback in set_state

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -270,7 +270,11 @@ class FSMFieldMixin(object):
         return getattr(instance, self.name)
 
     def set_state(self, instance, state):
-        instance.__dict__[self.name] = state
+        if self.name in instance.__dict__:
+            instance.__dict__[self.name] = state
+        else:
+            setattr(instance, self.name, state)
+
 
     def set_proxy(self, instance, state):
         """


### PR DESCRIPTION
In the same vein as #110 we shouldn't assume that the attribute exists in `__dict__`. This falls back to `setattr`.