### PR TITLE
Add passing args, kwargs

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -179,7 +179,7 @@ class FSMMeta(object):
 
         return False
 
-    def conditions_met(self, instance, state):
+    def conditions_met(self, instance, state, *args, **kwargs):
         """
         Check if all conditions have been met
         """
@@ -190,8 +190,9 @@ class FSMMeta(object):
         elif transition.conditions is None:
             return True
         else:
-            return all(map(lambda condition: condition(instance), transition.conditions))
-
+            return all(map(lambda condition:
+                           condition(instance, *args, **kwargs),
+                           transition.conditions))
     def has_transition_perm(self, instance, state, user):
         transition = self.get_transition(state)
 
@@ -301,7 +302,7 @@ class FSMFieldMixin(object):
             raise TransitionNotAllowed(
                 "Can't switch from state '{0}' using method '{1}'".format(current_state, method_name),
                 object=instance, method=method)
-        if not meta.conditions_met(instance, current_state):
+        if not meta.conditions_met(instance, current_state, *args, **kwargs):
             raise TransitionNotAllowed(
                 "Transition conditions have not been met for method '{0}'".format(method_name),
                 object=instance, method=method)


### PR DESCRIPTION
Following from #117, here is a first go at it. Let me know what you think.

The bad part, in my opinion, is that the condition function that accepts `*args` and `**kwargs` needs to check that they are present (not all methods that call `conditions_met` have access!). So, that isn't ideal.