### PR TITLE
Make README reflect deprecation re callable permission

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ perform the transition
 .. code:: python
 
     @transition(field=state, source='*', target='publish',
-                permission=lambda user: not user.has_perm('myapp.can_make_mistakes'))
+                permission=lambda instance, user: not user.has_perm('myapp.can_make_mistakes'))
     def publish(self):
         pass
 


### PR DESCRIPTION
As of [this commit on 2015-10-14](https://github.com/kmmbvnr/django-fsm/commit/452ab20682d9a4fbc3a0fde7057bdb48826fe75f) there's a warning when a callable permission with only user parameter is defined on a transition (ie. a callable permission should take two arguments; instance and user).