### PR TITLE
README update for `target` example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ on a model instance with a protected FSMField will cause an exception.
                 source='*',
                 target=RETURN_VALUE('for_moderators', 'published'))
     def publish(self, is_public=False):
-        return 'need_moderation' if is_public else 'published'
+        return 'for_moderators' if is_public else 'published'
 
     @transition(
         field=state,


### PR DESCRIPTION
The `publish` method in the example returns `need_moderation` or `published` whereas the `RETURN_VALUE` allows `for_moderators` and `published`.