### PR TITLE
Use ModelSignal instead of Signal in signals.py

### DIFF
--- a/django_fsm/signals.py
+++ b/django_fsm/signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.dispatch import Signal
+from django.db.models.signals import ModelSignal
 
-pre_transition = Signal(providing_args=['instance', 'name', 'source', 'target'])
-post_transition = Signal(providing_args=['instance', 'name', 'source', 'target', 'exception'])
+pre_transition = ModelSignal(providing_args=['instance', 'name', 'source', 'target'])
+post_transition = ModelSignal(providing_args=['instance', 'name', 'source', 'target', 'exception'])

--- a/django_fsm/signals.py
+++ b/django_fsm/signals.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
-from django.db.models.signals import ModelSignal
-
-pre_transition = ModelSignal(providing_args=['instance', 'name', 'source', 'target'])
-post_transition = ModelSignal(providing_args=['instance', 'name', 'source', 'target', 'exception'])
+try:
+  from django.db.models.signals import ModelSignal as Signal
+except ImportError:
+  # Django 1.6 compat
+  from django.dispatch import Signal
+  
+pre_transition = Signal(providing_args=['instance', 'name', 'source', 'target'])
+post_transition = Signal(providing_args=['instance', 'name', 'source', 'target', 'exception'])


### PR DESCRIPTION
Closes #158 

It's backwards compatible, the signal will act the same if a class is given rather than a string.