### PR TITLE
Fix in management command for Graphviz in Django 1.10.

### DIFF
--- a/django_fsm/management/commands/graph_transitions.py
+++ b/django_fsm/management/commands/graph_transitions.py
@@ -112,15 +112,24 @@ def add_transition(transition_source, transition_target, transition_name, source
 class Command(BaseCommand):
     requires_system_checks = True
 
-    option_list = BaseCommand.option_list + (
-        make_option('--output', '-o', action='store', dest='outputfile',
-                    help=('Render output file. Type of output dependent on file extensions. '
-                          'Use png or jpg to render graph to image.')),
-        # NOQA
-        make_option('--layout', '-l', action='store', dest='layout', default='dot',
-                    help=('Layout to be used by GraphViz for visualization. '
-                          'Layouts: circo dot fdp neato nop nop1 nop2 twopi')),
-    )
+    def add_arguments(self, parser):
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '--output', '-o',
+            action='store',
+            dest='outputfile',
+            help=('Render output file. Type of output dependent on file extensions. '
+                  'Use png or jpg to render graph to image.')
+        )
+        parser.add_argument(
+            '--layout', '-l',
+            action='store',
+            dest='layout',
+            default='dot',
+            help=('Layout to be used by GraphViz for visualization. '
+                  'Layouts: circo dot fdp neato nop nop1 nop2 twopi')
+        ),
 
     help = ("Creates a GraphViz dot file with transitions for selected fields")
     args = "[appname[.model[.field]]]"


### PR DESCRIPTION
Trying to graph the transitions with django_fsm 2.4.0 and Django 1.10.1 would raise this error:

```
$ python manage.py graph_transitions > transitions.dot
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/matiasherranz/.virtualenvs/invertio/lib/python2.7/site-packages/django/core/management/__init__.py", line 367, in execute_from_command_line
    utility.execute()
  File "/Users/matiasherranz/.virtualenvs/invertio/lib/python2.7/site-packages/django/core/management/__init__.py", line 359, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/matiasherranz/.virtualenvs/invertio/lib/python2.7/site-packages/django/core/management/__init__.py", line 208, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/Users/matiasherranz/.virtualenvs/invertio/lib/python2.7/site-packages/django/core/management/__init__.py", line 40, in load_command_class
    module = import_module('%s.management.commands.%s' % (app_name, name))
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/Users/matiasherranz/.virtualenvs/invertio/lib/python2.7/site-packages/django_fsm/management/commands/graph_transitions.py", line 102, in <module>
    class Command(BaseCommand):
  File "/Users/matiasherranz/.virtualenvs/invertio/lib/python2.7/site-packages/django_fsm/management/commands/graph_transitions.py", line 105, in Command
    option_list = BaseCommand.option_list + (
AttributeError: type object 'BaseCommand' has no attribute 'option_list'
```

This PR fixes the way the management command parameters are set up and fixes this error.
