### PR TITLE
Allow sets to be passed in the transition decorator

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -503,7 +503,7 @@ def transition(field, source='*', target=None, on_error=None, conditions=[], per
             fsm_meta = FSMMeta(field=field, method=func)
             setattr(func, '_django_fsm', fsm_meta)
 
-        if isinstance(source, (list, tuple)):
+        if isinstance(source, (list, tuple, set)):
             for state in source:
                 func._django_fsm.add_transition(func, state, target, on_error, conditions, permission, custom)
         else:


### PR DESCRIPTION
It's quite handy to be able to pass in a set of transitions, currently you have to do `@transition(source=list(some_set_of_transitions))`. Can we just pass the set in directly?