### PR TITLE
Remove second has_perm check in Transition.has_perm

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -97,8 +97,6 @@ class Transition(object):
             return bool(self.permission(instance, user))
         elif user.has_perm(self.permission, instance):
             return True
-        elif user.has_perm(self.permission):
-            return True
         else:
             return False
 


### PR DESCRIPTION
I think the permission checks here are slightly wrong, in that the second check is not needed.

If you're using an object-based permission system like `django-rules` the instance parameter is passed to the permission for you to check against. In the case that the user doesn't have the required permission it falls through to the second `has_perm` call without *the object*. This results in confusing permission errors where an object is expected, but the object is `None`.

The Django `has_perm` function accepts an instance as the second argument always, and by default it ignores it. Thus I think it's not needed?