### PR TITLE
Drop support of django<1.8 and python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
         "Framework :: Django :: 1.8",
         "Framework :: Django :: 1.9",
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,18 @@
 [tox]
 envlist =
-    py26-{dj16}
-    py27-{dj16,dj18,dj19,dj110}
-    py33-{dj16,dj18}
+    py27-{dj18,dj19,dj110}
+    py33-{dj18}
     py{34,35}-{dj18,dj19,dj110}
 skipsdist = True
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4
     py35: python3.5
 deps =
-    py26: ipython==2.1.0
     {py27,py32,py33,py34,py35}: ipython==4.1.1    
-    dj16: Django==1.6.11
-    dj16: django-jenkins==0.17.0
-    dj16: coverage<=3.999
-    dj16: django-guardian==1.3.2
     dj18: Django==1.8.13
     dj18: django-jenkins==0.18.1
     dj18: coverage==4.1


### PR DESCRIPTION
Seems the right thing to do.
It will improve CI performance a bit.