### PR TITLE
Add a test to demonstrate issue with django 1.11

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -222,7 +222,7 @@ class FSMFieldDescriptor(object):
 
     def __get__(self, instance, type=None):
         if instance is None:
-            raise AttributeError('Can only be accessed via an instance.')
+            return self
         return self.field.get_state(instance)
 
     def __set__(self, instance, value):

--- a/tests/testapp/tests/test_model_create_with_generic.py
+++ b/tests/testapp/tests/test_model_create_with_generic.py
@@ -1,0 +1,44 @@
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except ImportError:
+    # Django 1.6
+    from django.contrib.contenttypes.generic import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+from django.db import models
+from django.test import TestCase
+from django_fsm import FSMField, transition
+
+
+class Ticket(models.Model):
+
+    class Meta:
+        app_label = 'testapp'
+
+
+class Task(models.Model):
+    class STATE:
+        NEW = 'new'
+        DONE = 'done'
+
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    causality = GenericForeignKey('content_type', 'object_id')
+    state = FSMField(default=STATE.NEW)
+
+    @transition(field=state, source=STATE.NEW, target=STATE.DONE)
+    def do(self):
+        pass
+
+    class Meta:
+        app_label = 'testapp'
+
+
+class Test(TestCase):
+    def setUp(self):
+        self.ticket = Ticket.objects.create()
+
+    def test_model_objects_create(self):
+        """Check a model with state field can be created
+        if one of the other fields is a property or a virtual field.
+        """
+        Task.objects.create(causality=self.ticket)


### PR DESCRIPTION
If model with state field has other fields that access their field value
via a property or a Virtal Field, then creation of instances will fail.

I do not know yet how to fix it but I will work on it.