### PR TITLE
fix for django-1.11 compatibility

### DIFF
--- a/django_fsm/__init__.py
+++ b/django_fsm/__init__.py
@@ -222,7 +222,7 @@ class FSMFieldDescriptor(object):
 
     def __get__(self, instance, type=None):
         if instance is None:
-            raise AttributeError('Can only be accessed via an instance.')
+            return self
         return self.field.get_state(instance)
 
     def __set__(self, instance, value):


### PR DESCRIPTION
Django-1.11 now cache class and instance properties. I think is is better to allow class level property access.